### PR TITLE
use stable ubuntu version instead of latest one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:14.04
 MAINTAINER Pawel Pikula <pawel.pikula@erlang-solutions.com>
 
 ENV HOME /opt/mongooseim


### PR DESCRIPTION
I got errors when using latest ubuntu (utopic) when doing apt-get update. Using stable version all works.

Regards,

Jonathan
